### PR TITLE
Modify alm_get_default_repeater(), let the plug-in check if the curre…

### DIFF
--- a/core/functions.php
+++ b/core/functions.php
@@ -49,24 +49,33 @@ function alm_get_current_repeater($repeater, $type) {
 
 
 /*
-*  alm_get_default_repeater
-*  Get the default repeater template for current blog
-*
-*  @return $include (file path)
-*  @since 2.5.0
-*/
+ *  alm_get_default_repeater
+ *  Get the default repeater template for current blog
+ *  First check if there is default repeater template within the current template
+ *  If there is not then read the plug-in default template
+ *  @return $include (file path)
+ *  @since 2.5.0
+ */
 
 function alm_get_default_repeater() {
-	global $wpdb;
-	$blog_id = $wpdb->blogid;
-	
-	if($blog_id > 1){	
-		$file = ALM_PATH. 'core/repeater/'. $blog_id .'/default.php'; // File
-	}else{
-		$file = ALM_PATH. 'core/repeater/default.php';			
-	}
-	
-	return $file;
+    global $wpdb;
+    // Let user is able to load their customise template in theme
+    $template_theme_file = get_template_directory().'/repeater/default.php';
+    // load repeater template from current theme folder
+    if(file_exists($template_theme_file)){
+        $file = $template_theme_file;
+    }
+    // if cannot find such file, load from plug-in repeater folder
+    else{
+        $blog_id = $wpdb->blogid;
+        if($blog_id > 1){	
+            $file = ALM_PATH.'core/repeater/'.$blog_id.'/default.php'; // File
+        }
+        else{
+            $file = ALM_PATH.'core/repeater/default.php';			
+        }
+    }
+    return $file;
 }
 
 

--- a/core/functions.php
+++ b/core/functions.php
@@ -59,14 +59,25 @@ function alm_get_current_repeater($repeater, $type) {
 
 function alm_get_default_repeater() {
     global $wpdb;
+    $file = null;
     // Let user is able to load their customise template in theme
-    $template_theme_file = get_template_directory().'/repeater/default.php';
     // load repeater template from current theme folder
+    if(is_child_theme()){
+        $template_theme_file = get_stylesheet_directory().'/repeater/default.php';
+        // if child theme does not have repeater template, then use the parent theme dir
+        if(!file_exists($template_theme_file)){
+            $template_theme_file = get_template_directory().'/repeater/default.php';
+        }
+    }
+    else{
+        $template_theme_file = get_template_directory().'/repeater/default.php';
+    }
+    // if theme or child theme contains the template, use that file
     if(file_exists($template_theme_file)){
         $file = $template_theme_file;
     }
-    // if cannot find such file, load from plug-in repeater folder
-    else{
+    // otherwise use pre-defined plug-in template
+    if($file == null){
         $blog_id = $wpdb->blogid;
         if($blog_id > 1){	
             $file = ALM_PATH.'core/repeater/'.$blog_id.'/default.php'; // File


### PR DESCRIPTION
This is an improvement for the plug-in template loading process:
 first to check if the current theme has repeater default template (different from customised template from unlimited custom repeater template) and if yes then apply that template instead the plug-in one, otherwise use the template default plug-in