### PR TITLE
Allow the query to accept a slug instead of an id for author queries.

### DIFF
--- a/ajax-load-more.php
+++ b/ajax-load-more.php
@@ -375,8 +375,16 @@ if( !class_exists('AjaxLoadMore') ):
    		
    		$s = (isset($_GET['search'])) ? $_GET['search'] : '';   		
    		$custom_args = (isset($_GET['custom_args'])) ? $_GET['custom_args'] : '';
-   		$author_id = (isset($_GET['author'])) ? $_GET['author'] : '';
-   		
+
+   		// Author
+   		$author_raw = (isset($_GET['author'])) ? $_GET['author'] : '';
+   		if(!is_numeric($author_raw) && $author_raw !== '') {
+   			$author = get_user_by('slug', $author_raw);
+   			$author_id = (isset($author)) ? $author->ID : '';
+   		} else {
+   			$author_id = $author_raw;
+   		}
+
    		// Ordering
    		$order = (isset($_GET['order'])) ? $_GET['order'] : 'DESC';
    		$orderby = (isset($_GET['orderby'])) ? $_GET['orderby'] : 'date';


### PR DESCRIPTION
Hi,

At my company we use an htaccess rule to prevent User ID enumeration.
http://www.talsoft.com.ar/site/research/security-advisories/wordpress-user-id-and-user-name-disclosure/

This pull request allows the query to use the user slug instead of id.

The indentation seems a little odd but it is the same as the lines indented above them. I will fix it in whatever way you like.

Thanks.