### PR TITLE
Fixes missing preloaded array "category_name"

### DIFF
--- a/core/classes/class.alm-shortcode.php
+++ b/core/classes/class.alm-shortcode.php
@@ -322,6 +322,7 @@ if( !class_exists('ALM_SHORTCODE') ):
          		'post_type'          => $post_type,
          		'post_format'        => $post_format,
          		'category'           => $category,
+         		'category_name'      => $category,
          		'category__not_in'   => $category__not_in,
          		'tag'                => $tag,
          		'tag__not_in'        => $tag__not_in,


### PR DESCRIPTION
WP_Query() category parameter is "category_name”.