### PR TITLE
Added is_alm_query() & wp_alm_query() functions

### DIFF
--- a/ajax-load-more.php
+++ b/ajax-load-more.php
@@ -607,6 +607,8 @@ if ( ! class_exists( 'AjaxLoadMore' ) ) :
 					$alm_post_count  = $alm_query->post_count;
 					$alm_current     = 0;
 					$alm_has_cta     = false;
+					$is_alm_query    = false;
+					$wp_alm_query    = false;
 
 					$cta_array = [];
 					if ( $cta && has_action( 'alm_cta_pos_array' ) ) {
@@ -621,8 +623,10 @@ if ( ! class_exists( 'AjaxLoadMore' ) ) :
 
 						$alm_loop_count++;
 						$alm_current++; // Current item in loop.
-						$alm_page = $alm_page_count; // Get page number.
-						$alm_item = ( $alm_page_count * $posts_per_page ) - $posts_per_page + $alm_loop_count;
+						$alm_page     = $alm_page_count; // Get page number.
+						$alm_item     = ($alm_page_count * $posts_per_page) - $posts_per_page + $alm_loop_count;
+						$is_alm_query = true;
+						$wp_alm_query = $alm_query;
 
 						// Call to Action [Before].
 						if ( $cta && has_action( 'alm_cta_inc' ) && $cta_pos === 'before' && in_array( (string) $alm_current, $cta_array, true ) ) {
@@ -640,7 +644,10 @@ if ( ! class_exists( 'AjaxLoadMore' ) ) :
 						}
 
 					endwhile; wp_reset_query(); // phpcs:ignore
-
+					$is_alm_query = false;
+					$wp_alm_query = false;
+					$GLOBALS['is_alm_query'] = $is_alm_query;
+					$GLOBALS['wp_alm_query'] = $wp_alm_query;
 					// End Ajax Load More Loop.
 
 					$data = ob_get_clean();

--- a/core/functions.php
+++ b/core/functions.php
@@ -645,3 +645,25 @@ function alm_sticky_post__not_in( $ids = '', $not_in = '' ) {
 	}
 	return $ids;
 }
+
+/**
+ * Check if the current query is an ALM query.
+ *
+ * @since 5.5.1
+ * @return boolean
+ */
+function is_alm_query() {
+	global $is_alm_query;
+	return $is_alm_query;
+}
+
+/**
+ * Get the current ALM query.
+ *
+ * @since 5.5.1
+ * @return \WP_Query
+ */
+function wp_alm_query() {
+	global $wp_alm_query;
+	return $wp_alm_query;
+}


### PR DESCRIPTION
Hi there,

When I used your plugin in one of my projects, I had to make sure the $post global variable was in the alm_query loop.

Due to the lack of a global function or variable in the plugin code, I was unable to find a simple solution, so I fixed it by using "loop_start" and "loop_end" hooks

When the issue was fixed, I thought it might be a problem for other developers as well, so I added functions to the plugin that would fix it.

I hope it is useful